### PR TITLE
Update common.pp

### DIFF
--- a/manifests/profile/ceilometer/common.pp
+++ b/manifests/profile/ceilometer/common.pp
@@ -23,5 +23,6 @@ class iaas::profile::ceilometer::common (
   # Change default polling interval from 10min to 0.5m for all sources
   exec { 'ceilometer_pipeline_interval':
     command => "sed -i 's/interval: 600$/interval: 30/' /etc/ceilometer/pipeline.yaml",
+    path => ['/bin/'],
   }
 }


### PR DESCRIPTION
while using this class I got this error message

Error: Failed to apply catalog: Validation of Exec[ceilometer_pipeline_interval] failed: 'sed -i 's/interval: 600$/interval: 30/' /etc/ceilometer/pipeline.yaml' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/environments/cloud/modules/iaas/manifests/profile/ceilometer/common.pp:26
